### PR TITLE
Update log usage for new module version

### DIFF
--- a/const/tags.js
+++ b/const/tags.js
@@ -26,6 +26,7 @@ var tag_names = {
     '_STAT': 'Status',
     '_TYPE': 'File Type',
     '_UID': 'Universally Unique ID',
+    '_UPD': 'Updated',
     /* Standard tags */
     'ABBR': 'Abbreviation',
     'ADDR': 'Address',

--- a/index.js
+++ b/index.js
@@ -46,20 +46,24 @@ var opts = require('nomnom')
 
 
 log4js.configure({
-    appenders: [
-        { type: "console" }
-    ],
-    replaceConsole: true
+  appenders: {
+    access: { type: 'dateFile', filename: 'log/access.log', pattern: '-yyyy-MM-dd' },
+    app: { type: 'file', filename: 'log/app.log', maxLogSize: 10485760, numBackups: 3 },
+    errorFile: { type: 'file', filename: 'log/errors.log' },
+    errors: { type: 'logLevelFilter', level: 'error', appender: 'errorFile' }
+  },
+  categories: {
+    default: { appenders: ['app', 'errors'], level: 'info' },
+    http: { appenders: ['access'], level: 'info' }
+  }
 });
-
 var logger = log4js.getLogger();
 if (opts.quiet) {
-    logger.setLevel('ERROR');
+    logger.level = 'debug';
 }
 else if (! opts.verbose) {
-    logger.setLevel('INFO');
+    logger.level = 'debug';
 }
-
 
 var debug_streamer = new LogStreamer(logger.debug.bind(logger));
 var warn_streamer = new LogStreamer(logger.warn.bind(logger));


### PR DESCRIPTION
Update log usage for new module version.
Add a _UPD tag which was used in GEDCOM from an online source.

Please let me know if my code is correct. I implemented it based on the logjs documentation. 

Following advice of #1 I managed to get it imported and the logs say nodes imported with the database showing storage size used but neo4j can't see any nodes, labels or relationships.